### PR TITLE
Add integration.d.ts to package.json files

### DIFF
--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -27,6 +27,7 @@
 	"sideEffects": false,
 	"files": [
 		"integration.js",
+		"integration.d.ts",
 		"implementation.js",
 		"polyfill.js",
 		"polyfill.d.ts"


### PR DESCRIPTION
The type declarations for this package are not working due to the `integrations.d.ts` not being included in the `package.json` `files` field. This change:

- Adds `integrations.d.ts` to the `packages/worker/package.json` `files` list.

See #3 for more details.

Fixes #3